### PR TITLE
Performance fix for knob shadow to draw on a bezierpath

### DIFF
--- a/SevenSwitch.m
+++ b/SevenSwitch.m
@@ -134,6 +134,7 @@
     knob.layer.shadowRadius = 2.0;
     knob.layer.shadowOpacity = 0.5;
     knob.layer.shadowOffset = CGSizeMake(0, 3);
+    knob.layer.shadowPath = [UIBezierPath bezierPathWithRect:knob.bounds].CGPath;
     knob.layer.masksToBounds = NO;
     knob.userInteractionEnabled = NO;
     [self addSubview:knob];


### PR DESCRIPTION
This pull request fixes the performance of drawing the knob layer shadow by using a shadowpath; we were having scroll performance issues when using a uitableview with multiple checkboxes.
