### PR TITLE
Update designated initializer for Swift 1.2

### DIFF
--- a/SevenSwitch.swift
+++ b/SevenSwitch.swift
@@ -204,7 +204,7 @@ import QuartzCore
     /*
     *   Initialization
     */
-    override public init() {
+    public init() {
         super.init(frame: CGRectMake(0, 0, 50, 30))
         
         self.setup()


### PR DESCRIPTION
In swift 1.2 we don't need the `override` designation on `init()` for a UIView, as it only provides `init(frame:)`

This pull request can stay open until Xcode 6.3 is final