### PR TITLE
Set tintColor of thumbImageView to on or inactive color

### DIFF
--- a/SevenSwitch.podspec
+++ b/SevenSwitch.podspec
@@ -1,0 +1,15 @@
+Pod::Spec.new do |s|
+  s.name         = "SevenSwitch"
+  s.version      = "2.0.0"
+  s.summary      = "iOS7 style drop in replacement for UISwitch."
+  s.homepage     = "https://github.com/bvogelzang/SevenSwitch"
+  s.screenshots  = "https://raw.github.com/bvogelzang/SevenSwitch/master/ExampleImages/example.gif", "https://raw.github.com/bvogelzang/SevenSwitch/master/ExampleImages/example.png"
+  s.license      = { :type => "MIT", :file => "LICENSE" }
+  s.author             = { "Ben Vogelzang" => "bvogelzang@breuer.com" }
+  s.platform     = :ios, "8.0"
+  s.source       = { :git => "https://github.com/bvogelzang/SevenSwitch.git", :tag => "2.0.0" }
+  s.source_files  = "SevenSwitch.swift"
+  s.exclude_files = "Classes/Exclude"
+  s.frameworks = "UIKit", "QuartzCore"
+  s.requires_arc = true
+end

--- a/SevenSwitch.swift
+++ b/SevenSwitch.swift
@@ -432,7 +432,8 @@ import QuartzCore
                 else {
                     self.thumbView.frame = CGRectMake(self.bounds.size.width - (normalKnobWidth + 1), self.thumbView.frame.origin.y, normalKnobWidth, self.thumbView.frame.size.height)
                 }
-                
+
+                self.thumbImageView.tintColor = self.onTintColor
                 self.backgroundView.backgroundColor = self.onTintColor
                 self.backgroundView.layer.borderColor = self.onTintColor.CGColor
                 self.thumbView.backgroundColor = self.onThumbTintColor
@@ -451,7 +452,8 @@ import QuartzCore
             else {
                 thumbView.frame = CGRectMake(self.bounds.size.width - (normalKnobWidth + 1), thumbView.frame.origin.y, normalKnobWidth, thumbView.frame.size.height)
             }
-            
+
+            thumbImageView.tintColor = self.onTintColor
             backgroundView.backgroundColor = self.onTintColor
             backgroundView.layer.borderColor = self.onTintColor.CGColor
             thumbView.backgroundColor = self.onThumbTintColor
@@ -482,6 +484,7 @@ import QuartzCore
                 else {
                     self.thumbView.frame = CGRectMake(1, self.thumbView.frame.origin.y, normalKnobWidth, self.thumbView.frame.size.height);
                     self.backgroundView.backgroundColor = self.inactiveColor
+                    self.thumbImageView.tintColor = self.inactiveColor
                 }
                 
                 self.backgroundView.layer.borderColor = self.borderColor.CGColor
@@ -503,6 +506,7 @@ import QuartzCore
             else {
                 thumbView.frame = CGRectMake(1, thumbView.frame.origin.y, normalKnobWidth, thumbView.frame.size.height)
                 backgroundView.backgroundColor = self.inactiveColor
+                thumbImageView.tintColor = self.inactiveColor
             }
             backgroundView.layer.borderColor = self.borderColor.CGColor
             thumbView.backgroundColor = self.thumbTintColor

--- a/SevenSwitch.swift
+++ b/SevenSwitch.swift
@@ -193,7 +193,7 @@ import QuartzCore
     internal var thumbView: UIView!
     internal var onImageView: UIImageView!
     internal var offImageView: UIImageView!
-    internal var thumbImageView: UIImageView!
+    public var thumbImageView: UIImageView!
     // private
     private var currentVisualValue: Bool = false
     private var startTrackingValue: Bool = false

--- a/SevenSwitch.swift
+++ b/SevenSwitch.swift
@@ -442,7 +442,8 @@ import QuartzCore
                 else {
                     self.thumbView.frame = CGRect(x: self.bounds.size.width - (normalKnobWidth + 1), y: self.thumbView.frame.origin.y, width: normalKnobWidth, height: self.thumbView.frame.size.height)
                 }
-                
+
+                self.thumbImageView.tintColor = self.onTintColor
                 self.backgroundView.backgroundColor = self.onTintColor
                 self.backgroundView.layer.borderColor = self.onTintColor.cgColor
                 self.thumbView.backgroundColor = self.onThumbTintColor
@@ -468,7 +469,8 @@ import QuartzCore
             else {
                 thumbView.frame = CGRect(x: self.bounds.size.width - (normalKnobWidth + 1), y: thumbView.frame.origin.y, width: normalKnobWidth, height: thumbView.frame.size.height)
             }
-            
+
+            thumbImageView.tintColor = self.onTintColor
             backgroundView.backgroundColor = self.onTintColor
             backgroundView.layer.borderColor = self.onTintColor.cgColor
             thumbView.backgroundColor = self.onThumbTintColor
@@ -499,6 +501,7 @@ import QuartzCore
                 else {
                     self.thumbView.frame = CGRect(x: 1, y: self.thumbView.frame.origin.y, width: normalKnobWidth, height: self.thumbView.frame.size.height);
                     self.backgroundView.backgroundColor = self.inactiveColor
+                    self.thumbImageView.tintColor = self.inactiveColor
                 }
                 
                 self.backgroundView.layer.borderColor = self.borderColor.cgColor
@@ -527,6 +530,7 @@ import QuartzCore
             else {
                 thumbView.frame = CGRect(x: 1, y: thumbView.frame.origin.y, width: normalKnobWidth, height: thumbView.frame.size.height)
                 backgroundView.backgroundColor = self.inactiveColor
+                thumbImageView.tintColor = self.inactiveColor
             }
             backgroundView.layer.borderColor = self.borderColor.cgColor
             thumbView.backgroundColor = self.thumbTintColor

--- a/SevenSwitch.swift
+++ b/SevenSwitch.swift
@@ -391,11 +391,9 @@ import QuartzCore
             let normalKnobWidth = frame.size.height - 2
             if self.on {
                 thumbView.frame = CGRect(x: frame.size.width - (normalKnobWidth + 1), y: 1, width: frame.size.height - 2, height: normalKnobWidth)
-                thumbImageView.frame = CGRect(x: frame.size.width - normalKnobWidth, y: 0, width: normalKnobWidth, height: normalKnobWidth)
             }
             else {
                 thumbView.frame = CGRect(x: 1, y: 1, width: normalKnobWidth, height: normalKnobWidth)
-                thumbImageView.frame = CGRect(x: 0, y: 0, width: normalKnobWidth, height: normalKnobWidth)
             }
             
             thumbView.layer.cornerRadius = self.isRounded ? (frame.size.height * 0.5) - 1 : 2


### PR DESCRIPTION
This allows Template rendered images to be used as thum image which will get on tint color when the switch is on and the inactive color when it's off
