### PR TITLE
Corrected thumb image view position.

### DIFF
--- a/SevenSwitch.swift
+++ b/SevenSwitch.swift
@@ -391,15 +391,15 @@ import QuartzCore
             let normalKnobWidth = frame.size.height - 2
             if self.on {
                 thumbView.frame = CGRect(x: frame.size.width - (normalKnobWidth + 1), y: 1, width: frame.size.height - 2, height: normalKnobWidth)
-                thumbImageView.frame = CGRect(x: frame.size.width - normalKnobWidth, y: 0, width: normalKnobWidth, height: normalKnobWidth)
             }
             else {
                 thumbView.frame = CGRect(x: 1, y: 1, width: normalKnobWidth, height: normalKnobWidth)
-                thumbImageView.frame = CGRect(x: 0, y: 0, width: normalKnobWidth, height: normalKnobWidth)
             }
             
             thumbView.layer.cornerRadius = self.isRounded ? (frame.size.height * 0.5) - 1 : 2
             thumbView.layer.shadowPath = UIBezierPath(roundedRect: thumbView.bounds, cornerRadius: thumbView.layer.cornerRadius).cgPath
+
+			thumbImageView.frame = CGRect(x: 0, y: 0, width: normalKnobWidth, height: normalKnobWidth)
         }
     }
     


### PR DESCRIPTION
`thumbImageView` is a subview of `thumbView` but its `frame.x` coordinate calculated relative to switch control. Error positioning could be seen if you add following code to example projects file `ViewController.swift` at line 26.
```
mySwitch.thumbImage = UIImage( named: "cross" )
```

